### PR TITLE
#20 Changed integration class configuration annotations.

### DIFF
--- a/blog/service/impl/src/test/kotlin/com/excref/kotblog/blog/service/category/CategoryServiceIntegrationTest.kt
+++ b/blog/service/impl/src/test/kotlin/com/excref/kotblog/blog/service/category/CategoryServiceIntegrationTest.kt
@@ -4,17 +4,11 @@ import com.excref.kotblog.blog.service.test.AbstractServiceIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories
-import org.springframework.stereotype.Component
 
 /**
  * @author Ruben Vardanyan
  * @since 06/07/2017 12:42
  */
-@EnableAutoConfiguration
-@EnableJpaRepositories
-@Component
 class CategoryServiceIntegrationTest : AbstractServiceIntegrationTest() {
 
     //region Dependencies

--- a/blog/service/impl/src/test/kotlin/com/excref/kotblog/blog/service/tag/TagServiceIntegrationTest.kt
+++ b/blog/service/impl/src/test/kotlin/com/excref/kotblog/blog/service/tag/TagServiceIntegrationTest.kt
@@ -4,13 +4,11 @@ import com.excref.kotblog.blog.service.test.AbstractServiceIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 
 /**
  * @author Arthur Asatryan
  * @since 6/4/17 4:12 PM
  */
-@EnableAutoConfiguration
 class TagServiceIntegrationTest : AbstractServiceIntegrationTest() {
 
     //region Dependencies

--- a/blog/service/impl/src/test/kotlin/com/excref/kotblog/blog/service/test/AbstractServiceIntegrationTest.kt
+++ b/blog/service/impl/src/test/kotlin/com/excref/kotblog/blog/service/test/AbstractServiceIntegrationTest.kt
@@ -5,6 +5,7 @@ import org.junit.Ignore
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.test.context.ContextConfiguration
@@ -15,13 +16,9 @@ import org.springframework.test.context.junit4.SpringRunner
  * @author Arthur Asatryan
  * @since 6/4/17 4:09 PM
  */
-// todo: see issue #20
-@RunWith(SpringRunner::class)
-@SpringBootTest
-@EnableJpaRepositories(basePackages = arrayOf("com.excref.kotblog.blog.persistence.*"))
-@EntityScan(basePackages = arrayOf("com.excref.kotblog.blog.service.*"))
+@DataJpaTest
+@EntityScan(basePackages = arrayOf("com.excref.kotblog.blog.service"))
 @ContextConfiguration("classpath:applicationContext-service.xml")
-@Ignore
 abstract class AbstractServiceIntegrationTest : AbstractTransactionalJUnit4SpringContextTests() {
 
     //region Dependencies

--- a/blog/service/impl/src/test/kotlin/com/excref/kotblog/blog/service/user/UserServiceIntegrationTest.kt
+++ b/blog/service/impl/src/test/kotlin/com/excref/kotblog/blog/service/user/UserServiceIntegrationTest.kt
@@ -11,7 +11,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration
  * @author Arthur Asatryan
  * @since 6/8/17 1:21 AM
  */
-@EnableAutoConfiguration
 class UserServiceIntegrationTest : AbstractServiceIntegrationTest() {
 
     //region Dependencies


### PR DESCRIPTION
`@DataJpaTest` is needed for JPA related spring boot configuration
`@EntityScan(basePackages = arrayOf("com.excref.kotblog.blog.service"))` needed to scan entity clasess. One little thing here, for `basePackages` property you don't need to pass package pattern, it will not work. Just pass the top package name and the child packages will be scanned.
`@ContextConfiguration("classpath:applicationContext-service.xml")` needed to run integration tests with proper spring application context 

With this annotations we will not need to add `@EnableAutoconfiguration` annotation for each integration test class.

Also fixed issue with separate spring boot application instances for each test. Now all tests are running under one spring boot application.

We don't need to use `@RunWith` annotation here, because `@DataJpaTest` already doing the work for that and tests are running with `SpringJUnit4ClassRunner` 